### PR TITLE
chore: ignore cypress videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 package-lock.json
 
 tests/public/assets
+tests/cypress/videos


### PR DESCRIPTION
This PR adds `tests/cypress/videos` to `.gitignore`, we definitely don't want to version these videos.